### PR TITLE
Add support for listing and creating entities of more types

### DIFF
--- a/packages/pieces/community/drupal/package.json
+++ b/packages/pieces/community/drupal/package.json
@@ -6,5 +6,10 @@
   "types": "./src/index.d.ts",
   "dependencies": {
     "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "@activepieces/shared": "*",
+    "@activepieces/pieces-framework": "*",
+    "@activepieces/pieces-common": "*"
   }
 }

--- a/packages/pieces/community/drupal/src/index.ts
+++ b/packages/pieces/community/drupal/src/index.ts
@@ -9,7 +9,9 @@ import {
 } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/shared';
 import { drupalCallToolAction } from './lib/actions/tools';
-import { drupalCreateContentAction } from './lib/actions/create_content';
+import { drupalCreateEntityAction } from './lib/actions/create_entity';
+import { drupalListEntitiesAction } from './lib/actions/list_entities';
+import { drupalGetEntityAction } from './lib/actions/get_entity';
 import { drupalPolling } from './lib/triggers/polling';
 import { drupalWebhook } from './lib/triggers/webhook';
 
@@ -87,6 +89,11 @@ export const drupal = createPiece({
     PieceCategory.MARKETING,
   ],
   authors: ['jurgenhaas'],
-  actions: [drupalCallToolAction, drupalCreateContentAction],
+  actions: [
+    drupalCallToolAction, 
+    drupalCreateEntityAction, 
+    drupalListEntitiesAction, 
+    drupalGetEntityAction
+  ],
   triggers: [drupalPolling, drupalWebhook],
 });

--- a/packages/pieces/community/drupal/src/lib/actions/get_entity.ts
+++ b/packages/pieces/community/drupal/src/lib/actions/get_entity.ts
@@ -1,0 +1,60 @@
+import {
+  PiecePropValueSchema,
+  Property,
+  createAction,
+} from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { drupalAuth } from '../../';
+import { fetchEntityTypes, makeEntityRequest } from '../common/entity-utils';
+
+type DrupalAuthType = PiecePropValueSchema<typeof drupalAuth>;
+
+export const drupalGetEntityAction = createAction({
+  auth: drupalAuth,
+  name: 'drupal-get-entity',
+  displayName: 'Get Entity',
+  description: 'Retrieve a single entity by ID or UUID',
+  props: {
+    entity_type: Property.Dropdown({
+      displayName: 'Entity Type',
+      description: 'The entity type to retrieve.',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        return await fetchEntityTypes(auth as DrupalAuthType);
+      },
+    }),
+    entity_id: Property.ShortText({
+      displayName: 'Entity ID or UUID',
+      description: 'The ID or UUID of the entity to retrieve',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const requestBody = {
+      entity_type: propsValue.entity_type.id,
+      entity_id: propsValue.entity_id,
+    };
+
+    console.debug('Entity get request', requestBody);
+    
+    const result = await makeEntityRequest(
+      auth as DrupalAuthType,
+      `/modeler_api/entity/get`,
+      HttpMethod.POST,
+      requestBody
+    );
+    
+    console.debug('Entity get call completed', result);
+
+    if (result.status === 200) {
+      return result.body;
+    } else if (result.status === 404) {
+      throw new Error(`Entity not found: ${propsValue.entity_id}`);
+    } else if (result.status === 403) {
+      throw new Error(`Access denied to entity: ${propsValue.entity_id}`);
+    } else {
+      throw new Error(`Failed to retrieve entity: ${result.status} - ${JSON.stringify(result.body)}`);
+    }
+  },
+});

--- a/packages/pieces/community/drupal/src/lib/actions/list_entities.ts
+++ b/packages/pieces/community/drupal/src/lib/actions/list_entities.ts
@@ -1,0 +1,111 @@
+import {
+  PiecePropValueSchema,
+  Property,
+  createAction,
+} from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { drupalAuth } from '../../';
+import { fetchEntityTypes, makeEntityRequest, createEntityFilters } from '../common/entity-utils';
+
+type DrupalAuthType = PiecePropValueSchema<typeof drupalAuth>;
+
+export const drupalListEntitiesAction = createAction({
+  auth: drupalAuth,
+  name: 'drupal-list-entities',
+  displayName: 'List Entities',
+  description: 'List entities of any type (content, users, taxonomy terms, etc.)',
+  props: {
+    entity_type: Property.Dropdown({
+      displayName: 'Entity Type',
+      description: 'The entity type to list.',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        return await fetchEntityTypes(auth as DrupalAuthType);
+      },
+    }),
+    filters: Property.DynamicProperties({
+      displayName: 'Filters',
+      refreshers: ['entity_type'],
+      required: false,
+      props: async ({ entity_type }) => createEntityFilters(entity_type),
+    }),
+    sort_field: Property.Dropdown({
+      displayName: 'Sort Field',
+      description: 'Field to sort by (leave empty for default sorting)',
+      required: false,
+      refreshers: ['entity_type'],
+      options: async ({ entity_type }) => {
+        if (!(entity_type as any)?.fields) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Select entity type first',
+          };
+        }
+
+        // Show all sortable fields from the entity definition
+        const entityFields = (entity_type as any).fields || [];
+        
+        const sortableFields = entityFields
+          .filter((field: any) => ['string', 'integer', 'decimal', 'float', 'timestamp'].includes(field.type))
+          .map((field: any) => ({ label: field.label, value: field.key }));
+
+        return {
+          disabled: false,
+          options: sortableFields,
+        };
+      },
+    }),
+    sort_direction: Property.StaticDropdown({
+      displayName: 'Sort Direction',
+      description: 'Sort direction',
+      required: false,
+      defaultValue: 'DESC',
+      options: {
+        options: [
+          { label: 'Descending', value: 'DESC' },
+          { label: 'Ascending', value: 'ASC' },
+        ],
+      },
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const { website_url } = auth as DrupalAuthType;
+    
+    // Build conditions from dynamic filters
+    const conditions: Record<string, any> = {};
+    if (propsValue.filters) {
+      Object.entries(propsValue.filters).forEach(([key, value]) => {
+        // Only include filters that have values
+        if (value !== undefined && value !== null && value !== '') {
+          conditions[key] = value;
+        }
+      });
+    }
+
+    const requestBody = {
+      entity_type: propsValue.entity_type.id,
+      conditions,
+      sort_field: propsValue.sort_field || undefined,
+      sort_direction: propsValue.sort_direction || 'DESC',
+    };
+
+    console.debug('Entity list request', requestBody);
+    
+    const result = await makeEntityRequest(
+      auth as DrupalAuthType,
+      `/modeler_api/entity/list`,
+      HttpMethod.POST,
+      requestBody
+    );
+    
+    console.debug('Entity list call completed', result);
+
+    if (result.status === 200) {
+      return result.body;
+    } else {
+      throw new Error(`Failed to list entities: ${result.status} - ${JSON.stringify(result.body)}`);
+    }
+  },
+});

--- a/packages/pieces/community/drupal/src/lib/common/entity-utils.ts
+++ b/packages/pieces/community/drupal/src/lib/common/entity-utils.ts
@@ -1,0 +1,120 @@
+import {
+  HttpMethod,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { PiecePropValueSchema, Property } from '@activepieces/pieces-framework';
+import { drupalAuth } from '../../';
+
+type DrupalAuthType = PiecePropValueSchema<typeof drupalAuth>;
+
+export interface DrupalEntityType {
+  id: string;
+  label: string;
+  description: string;
+  fields: DrupalEntityTypeFields[];
+}
+
+export interface DrupalEntityTypeFields {
+  key: string;
+  label: string;
+  description: string;
+  required: boolean;
+  type: string;
+  default_value: string;
+  options?: DrupalEntityTypeFieldTypeSelectOptions[];
+}
+
+export interface DrupalEntityTypeFieldTypeSelectOptions {
+  key: string;
+  name: string;
+}
+
+/**
+ * Fetches available entity types from Drupal
+ */
+export async function fetchEntityTypes(auth: DrupalAuthType) {
+  const { website_url, api_key } = auth;
+  
+  if (!auth) {
+    return {
+      disabled: true,
+      options: [],
+      placeholder: 'Please authenticate first.',
+    };
+  }
+
+  try {
+    const response = await httpClient.sendRequest<DrupalEntityType[]>({
+      method: HttpMethod.GET,
+      url: website_url + `/modeler_api/entity_types`,
+      headers: {
+        'x-api-key': api_key,
+      },
+    });
+    
+    console.debug('Entity types response', response);
+    if (response.status === 200) {
+      return {
+        disabled: false,
+        options: response.body.map((entity_type) => {
+          return {
+            label: entity_type.label,
+            description: entity_type.description,
+            value: entity_type,
+          };
+        }),
+      };
+    }
+  } catch (e: any) {
+    console.debug('Entity types error', e);
+  }
+  
+  return {
+    disabled: true,
+    options: [],
+    placeholder: 'Error processing entity types',
+  };
+}
+
+/**
+ * Makes a generic entity API request
+ */
+export async function makeEntityRequest<T = any>(
+  auth: DrupalAuthType,
+  endpoint: string,
+  method: HttpMethod = HttpMethod.GET,
+  body?: any
+) {
+  const { website_url, api_key } = auth;
+  
+  const request = {
+    method,
+    url: website_url + endpoint,
+    headers: {
+      'x-api-key': api_key,
+    },
+    ...(body && { body }),
+  };
+
+  return await httpClient.sendRequest<T>(request);
+}
+
+/**
+ * Creates dynamic filter properties for an entity type
+ */
+export function createEntityFilters(entity_type: any) {
+  // Simple status filter only
+  return {
+    status: Property.StaticDropdown({
+      displayName: 'Status',
+      required: false,
+      options: { 
+        options: [
+          { label: 'All', value: '' },
+          { label: 'Published', value: '1' }, 
+          { label: 'Unpublished', value: '0' }
+        ] 
+      },
+    }),
+  };
+}


### PR DESCRIPTION
- Replaced 'Create Content' with 'Create Entity' and added support for all entity types (e.g. content, taxonomy terms, users, etc.)
- Added 'Get Entity' action for retrieving single entities by their ID
- Added 'List Entities' action with basic filtering and sorting options
